### PR TITLE
Easy build of FW variants

### DIFF
--- a/merge_firmware.py
+++ b/merge_firmware.py
@@ -1,0 +1,40 @@
+Import("env")
+
+APP_BIN = "$BUILD_DIR/${PROGNAME}.bin"
+MERGED_BIN = "$BUILD_DIR/${PROGNAME}_merged.bin"
+BOARD_CONFIG = env.BoardConfig()
+
+def merge_bin(source, target, env):
+    # The list contains all extra images (bootloader, partitions, eboot) and
+    # the final application binary
+    flash_images = env.Flatten(env.get("FLASH_EXTRA_IMAGES", [])) + ["$ESP32_APP_OFFSET", APP_BIN]
+
+    # Run esptool to merge images into a single binary
+    env.Execute(
+        " ".join(
+            [
+                "$PYTHONEXE",
+                "$OBJCOPY",
+                "--chip",
+                BOARD_CONFIG.get("build.mcu", "esp32"),
+                "merge_bin",
+                "-o",
+                MERGED_BIN,
+            ]
+            + flash_images
+        )
+    )
+
+# Add a post action that runs esptoolpy to merge available flash images
+env.AddPostAction(APP_BIN , merge_bin)
+
+# Patch the upload command to flash the merged binary at address 0x0
+env.Replace(
+    UPLOADERFLAGS=[
+            f
+            for f in env.get("UPLOADERFLAGS")
+            if f not in env.Flatten(env.get("FLASH_EXTRA_IMAGES"))
+        ]
+        + ["0x0", MERGED_BIN],
+    UPLOADCMD='"$PYTHONEXE" "$UPLOADER" $UPLOADERFLAGS',
+)

--- a/platformio.ini
+++ b/platformio.ini
@@ -8,7 +8,7 @@
 ; Please visit documentation for the other options and examples
 ; https://docs.platformio.org/page/projectconf.html
 
-[env:paperboard]
+[env]
 platform = espressif32
 board = esp32-s3-devkitc-1
 framework = arduino
@@ -23,6 +23,35 @@ lib_deps =
 	WiFi
 	madhephaestus/ESP32AnalogRead@^0.3.0
 	wnatth3/WiFiManager@^2.0.16-rc.2
+extra_scripts =
+	merge_firmware.py
+
+[sensor_libraries]
+lib_deps =
 	adafruit/Adafruit SHT4x Library@^1.0.3
 	adafruit/Adafruit BME280 Library@^2.2.4
 	sparkfun/SparkFun SCD4x Arduino Library@^1.1.2
+
+[env:paperboard_ed060xc3]
+build_flags =
+	-D EPAPER_MODEL=ED060XC3
+
+[env:paperboard_ed060xc3_sensor]
+lib_deps = 
+	${env.lib_deps}
+	${sensor_libraries.lib_deps}
+build_flags =
+	-D EPAPER_MODEL=ED060XC3
+	-D SENSOR
+
+[env:paperboard_ed097tc2]
+build_flags =
+	-D EPAPER_MODEL=ED097TC2
+
+[env:paperboard_ed097tc2_sensor]
+lib_deps = 
+	${env.lib_deps}
+	${sensor_libraries.lib_deps}
+build_flags =
+	-D EPAPER_MODEL=ED097TC2
+	-D SENSOR

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -26,16 +26,23 @@
 #define BOARD sverio_paperboard_v1
 
 // choose a screen type, ED060XC3 or ED097TC2
-//#define EPAPER_MODEL ED097TC2
-#define EPAPER_MODEL ED060XC3
+#ifndef EPAPER_MODEL
+  #define EPAPER_MODEL ED097TC2
+  //#define EPAPER_MODEL ED060XC3
+#endif
+
+// choose VCOM voltage
+#if defined(EPAPER_MODEL) && (EPAPER_MODEL == ED060XC3)
+  // 100 seems better for 6" screens
+  #define VCOM_VOLTAGE 100
+#endif
+
+#if defined(EPAPER_MODEL) && (EPAPER_MODEL == ED097TC2)
+  #define VCOM_VOLTAGE 1500
+#endif
 
 #define STRINGIFY(x) #x
 #define TOSTRING(x) STRINGIFY(x)
-
-// choose VCOM voltage
-// 100 seems better for 6" screens
-//#define VCOM_VOLTAGE 1500
-#define VCOM_VOLTAGE 100
 
 // map the colors
 // full 16 color scale is below: 
@@ -52,7 +59,7 @@
 
 // uncomment if one of the sensors will be connected
 // supported sensors: SHT40/41/45, SCD40/41, BME280 
-//#define SENSOR
+// #define SENSOR
 #define PIN_SDA 39
 #define PIN_SCL 40
 


### PR DESCRIPTION
Added directives that specify what type of display (with or without sensor support) should be built. Now you can use "Build all" in Platformio to generate all 4 variants (for now ;)).